### PR TITLE
Preserve own function props

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ module.exports = function hookable(fn) {
     return fn.apply(this, [].slice.call(arguments))
   }
 
+  Object.assign(hooked, fn)
+
   hooked.hook = function (hook) {
     fn = wrap(fn, hook)
     return this

--- a/test/index.js
+++ b/test/index.js
@@ -129,3 +129,24 @@ tape('check a thing, maybe return something different, else change result', func
   t.end()
 
 })
+
+tape('preserve own properties', function (t) {
+
+  var add = function (a, b) {
+    return a + b
+  };
+
+  add.operation = 'addition'
+  add.obj = {}
+  add.hook = null
+
+  var h = Hoox(add)
+
+  t.equal(h(2, 4), 6)
+  t.equal(h.operation, 'addition')
+  t.deepEqual(h.obj, {})
+  t.ok(typeof h.hook === 'function')
+
+  t.end()
+
+})


### PR DESCRIPTION
I was hoping to write a utility that adds some properties to a function, similar to how hoox adds a `hook` property.  This utility is used in the context of secret-stack, so the function is eventually wrapped using hoox which doesn't currently preserve these properties.  Proposed here is a backwards-compatible change to preserve the original function's own properties.  Here's a little example to illustrate:
```js
  var add = function (a, b) {
    return a + b
  };

  add.operation = 'addition'

  var h = Hoox(add)

  t.equal(h.operation, 'addition')
```